### PR TITLE
add hint for pybind11 python discovery

### DIFF
--- a/cpp_cuda_c/CMakeLists.txt
+++ b/cpp_cuda_c/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
+cmake_policy(SET CMP0094 NEW)
 
 project(SplinePSF LANGUAGES CXX C)
 

--- a/dist_tools/conda/spline/meta.yaml
+++ b/dist_tools/conda/spline/meta.yaml
@@ -12,19 +12,19 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - python {{ python }}
-    - cmake >=3.14
+    - python
+    - cmake >=3.15
     - ninja
     - setuptools
 
   host:
-    - python {{ python }}
+    - python
     - numpy {{ numpy }}
     - pybind11 >=2.4
     - cudatoolkit-dev # [linux]
 
   run:
-    - {{ pin_compatible('python', max_pin='x.x') }}
+    - python
     - {{ pin_compatible('numpy', max_pin='x.x') }}
     # - cudatoolkit=10.1  # [linux]
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -34,15 +34,17 @@ class CMakeBuild(build_ext):
             self.build_extension(ext)
 
     def build_extension(self, ext):
+        env = os.environ.copy()
+        py_ver = ".".join(env["PY_VER"].split())
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
         # self.debug = True
         cfg = 'Debug' if self.debug else 'Release'
         build_args = ['--config', cfg]
         cmake_args = ['-DCMAKE_BUILD_TYPE=' + cfg]
         cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir]
+        cmake_args += [f'-DPYBIND11_PYTHON_VERSION={py_ver}']
         cmake_args += ["-GNinja"]
 
-        env = os.environ.copy()
         env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get('CXXFLAGS', ''),
                                                               self.distribution.get_version())
         if not os.path.exists(self.build_temp):


### PR DESCRIPTION
This fixes the version problems for me...
turned out to be both a conda, and some cmake weirdness.

* takeaways: pybind11 is looking for python in a different way than `find_package(python)`
* [CMP0094](https://cmake.org/cmake/help/v3.17/policy/CMP0094.html#policy:CMP0094) controls how Python is found.